### PR TITLE
Fixed github banner broken link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
 <a href="#download" class="download" title="Click to download ->">Only <strong>1-2KB</strong> minified</a>
 
 <a href="https://github.com/LeaVerou/chainvas" class="github">
-	<img src="https://a248.e.akamai.net/assets.github.com/img/5d21241b64dc708fcbb701f68f72f41e9f1fadd6/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub">
+	<img src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png" alt="Fork me on GitHub">
 </a>
 
 <div id="toc">


### PR DESCRIPTION
I changed the image link for the gihub banner because it was broken.
