### PR TITLE
Change download link to Blob URL.

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,8 +111,12 @@ form.elements.compression[1].onclick = function() {
 				codeParts.push(code[id].code);
 			}
 		}
-		
-		this.href = 'data:text/javascript;charset=utf-8,' + encodeURIComponent(codeParts.join('\r\n'));
+		var blob = new Blob(
+			[codeParts.join('\r\n')],
+			{type : 'text/javascript'}
+		);
+		this.href = URL.createObjectURL(blob);
+		this.download = 'chainvas.js';
 	};
 };
 


### PR DESCRIPTION
Fixes #14.

I could not get the blob to open in a new window because [popular Ad Blocker software has problems opening blob URLs in a new window](https://stackoverflow.com/a/43471281/1104036). I added the `download` attribute to the anchor instead, so a `chanvas.js` file will download when the user clicks the link.